### PR TITLE
Implement download export.

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ export it. See gdpr_export.api.php for more information on that.
 ## Setup
 
 The module requires the [Entity API](https://www.drupal.org/project/entity)
-module as well as the [Symfony 4.x Serializer](https://www.drupal.org/project/entity).
+module as well as the [Symfony 3.x Serializer](https://symfony.com/doc/3.4/serializer.html).
 
 It is up to you how to add the Symfony Serializer as a dependency. You either
 use either the [composer manager](https://www.drupal.org/project/composer_manager)

--- a/gdpr_export.api.php
+++ b/gdpr_export.api.php
@@ -94,15 +94,28 @@ function hook_gdpr_export_user_normalizer_alter(&$properties, $user_wrapper) {
  *   The user account for which the data should be exported.
  * @param string $directory
  *   The directory where new files should be saved to.
+ * @param string $format
+ *   The format which should be used for the export. Currently only 'xml' and
+ *   'json' are supported.
  *
  * @return bool|string
  *   A string with the path of the file to export, or FALSE on error.
  */
-function hook_gdpr_export_user_export($account, $directory) {
+function hook_gdpr_export_user_export($account, $directory, $format) {
   // Export the basic user account data.
   $meta = entity_metadata_wrapper('user', $account);
-  $data = gdpr_export_serialize_entity($meta);
-  return file_unmanaged_save_data($data, "$directory/user.xml");
+  $data = gdpr_export_serialize_entity($meta, $format);
+  return file_unmanaged_save_data($data, "$directory/user.$format");
+}
+
+/**
+ * Change the format used for the exports.
+ *
+ * @param string $format
+ *   Either json or xml (default).
+ */
+function hook_gdpr_export_user_export_format_alter(&$format) {
+  $format = 'json';
 }
 
 /**

--- a/gdpr_export.api.php
+++ b/gdpr_export.api.php
@@ -80,5 +80,32 @@ function hook_gdpr_export_user_normalizer_alter(&$properties, $user_wrapper) {
 }
 
 /**
+ * Allows to register new files to be exported with the user data.
+ *
+ * If additional data should be exported, for example a profile or a node
+ * related to the account, then modules should implement this hook.
+ * New entities can be exported using gdpr_export_serialize_entity() and should
+ * be saved to the $directory parameter using file_unmanaged_save_data(),
+ * so that data is cleared after the files where zipped and downloaded.
+ * If an existing file should be added to the export, than just return the path
+ * to it.
+ *
+ *
+ * @param object $account
+ *   The user account for which the data should be exported.
+ * @param string $directory
+ *   The directory where new files should be saved to.
+ *
+ * @return bool|string
+ *   A string with the path of the file to export, or FALSE on error.
+ */
+function hook_gdpr_export_user_export($account, $directory) {
+  // Export the basic user account data.
+  $meta = entity_metadata_wrapper('user', $account);
+  $data = gdpr_export_serialize_entity($meta);
+  return file_unmanaged_save_data($data, "$directory/user.xml");
+}
+
+/**
  * @} End of "addtogroup hooks".
  */

--- a/gdpr_export.api.php
+++ b/gdpr_export.api.php
@@ -90,7 +90,6 @@ function hook_gdpr_export_user_normalizer_alter(&$properties, $user_wrapper) {
  * If an existing file should be added to the export, than just return the path
  * to it.
  *
- *
  * @param object $account
  *   The user account for which the data should be exported.
  * @param string $directory

--- a/gdpr_export.api.php
+++ b/gdpr_export.api.php
@@ -102,10 +102,12 @@ function hook_gdpr_export_user_normalizer_alter(&$properties, $user_wrapper) {
  *   A string with the path of the file to export, or FALSE on error.
  */
 function hook_gdpr_export_user_export($account, $directory, $format) {
-  // Export the basic user account data.
-  $meta = entity_metadata_wrapper('user', $account);
+  // Export a certain profile from the profile2 module. An appropriate profile2
+  // would have to be implemented though.
+  $profile = profile2_load_by_user($account, 'user_profile');
+  $meta = entity_metadata_wrapper('profile2', $profile);
   $data = gdpr_export_serialize_entity($meta, $format);
-  return file_unmanaged_save_data($data, "$directory/user.$format");
+  return file_unmanaged_save_data($data, "$directory/user_profile.$format");
 }
 
 /**

--- a/gdpr_export.module
+++ b/gdpr_export.module
@@ -183,3 +183,26 @@ function gdpr_export_gdpr_export_normalizer_info() {
     'GDPRExportGenericDataNormalizer' => 5,
   ];
 }
+
+/**
+ * Implements hook_form_FORM_ID_alter().
+ */
+function gdpr_export_form_user_profile_form_alter(&$form, &$form_state, $form_id) {
+  // @todo: does it makes sense to place the export link in the edit form.
+  global $user;
+  $account_uid = $form['#user']->uid;
+
+  if (user_access('administer users')
+    || $account_uid == $user->uid
+  ) {
+    $form['actions']['gdpr_export_data'] = [
+      '#type' => 'submit',
+      '#value' => t('Export all data'),
+      '#submit' => ['gdpr_export_user_data_submit'],
+    ];
+  }
+}
+
+function gdpr_export_user_data_submit(&$form, &$form_state) {
+  drupal_goto('user/' . $form['#user']->uid . '/gdpr_export');
+}

--- a/gdpr_export.module
+++ b/gdpr_export.module
@@ -192,7 +192,7 @@ function gdpr_export_form_user_profile_form_alter(&$form, &$form_state, $form_id
   global $user;
   $account_uid = $form['#user']->uid;
 
-  if (user_access('administer users')
+  if (user_access('bypass gdpr user export')
     || $account_uid == $user->uid
   ) {
     $form['actions']['gdpr_export_data'] = [

--- a/gdpr_export.module
+++ b/gdpr_export.module
@@ -87,20 +87,26 @@ function gdpr_export_user_export($account) {
 
   // Send it to the client. Taken from:
   // https://drupal.stackexchange.com/questions/33177/how-to-download-zip-file-through-browser
+  // and @see file_transfer().
+
+  if (ob_get_level()) {
+    ob_end_clean();
+  }
+
   // Most of this is only necessary because of IE
-  header("Cache-Control: public");
-  header("Content-Type: application/octet-stream");
-  header("Cache-Control: no-store, no-cache, must-revalidate");
-  header("Cache-Control: post-check=0, pre-check=0");
-  header("Content-Disposition: attachment; filename=\"$filename\";" );
-  header("Content-Transfer-Encoding: binary");
+  drupal_add_http_header("Cache-Control: public, no-store, no-cache, must-revalidate, post-check=0, pre-check=0");
+  drupal_add_http_header("Content-Type: application/octet-stream");
+  drupal_add_http_header("Content-Disposition: attachment; filename=\"$filename\";" );
+  drupal_add_http_header("Content-Transfer-Encoding: binary");
 
   $fp = fopen($zip_path, 'rb');
   fpassthru($fp);
+  fclose($fp);
 
   // Delete the directory, so that we don't have any dangling files with
   // personal information.
   file_unmanaged_delete_recursive($file_path);
+  drupal_exit();
 }
 
 /**

--- a/gdpr_export.module
+++ b/gdpr_export.module
@@ -101,7 +101,7 @@ function gdpr_export_user_export($account) {
   // Most of this is only necessary because of IE
   drupal_add_http_header('Cache-Control', 'public, no-store, no-cache, must-revalidate, post-check=0, pre-check=0');
   drupal_add_http_header('Content-Type',  'application/octet-stream');
-  drupal_add_http_header('Content-Disposition', "attachment; filename='$filename';" );
+  drupal_add_http_header('Content-Disposition', "attachment; filename=$filename;" );
   drupal_add_http_header('Content-Transfer-Encoding', 'binary');
 
   $fp = fopen($zip_path, 'rb');

--- a/gdpr_export.module
+++ b/gdpr_export.module
@@ -14,7 +14,7 @@ use Symfony\Component\Serializer\Encoder\XmlEncoder;
  * Implements hook_menu().
  */
 function gdpr_export_menu() {
-  $items['user/%user/gdpr_export_download'] = [
+  $items['user/%user/gdpr_export'] = [
     'title' => 'User data export',
     'page callback' => 'gdpr_export_user_export',
     'page arguments' => [1],
@@ -54,7 +54,53 @@ function gdpr_export_user_export_access($account) {
  *   The account for which the user should be exported.
  */
 function gdpr_export_user_export($account) {
+  // Create a directory, where all export files which should be saved.
+  // @todo: figure how to create a truly unique file dir.
+  $directory = 'temporary://gdpr_export_' . $account->uid . '/' . REQUEST_TIME;
+  file_prepare_directory($directory, FILE_CREATE_DIRECTORY);
 
+  // Invoke all hooks that export user data. They should do that by saving a new
+  // file into the given $directory and return the resulting filename
+  // & path from as returned from file_unmanaged_save_data().
+  $files = module_invoke_all('gdpr_export_user_export', $account, $directory);
+
+  // Base name for the zip file and uncompressed folder.
+  $zip_base = $account->uid . '_export';
+  $filename = "$zip_base.zip";
+
+  // @todo: check if this is a good path for the zip file.
+  $zip_path = drupal_realpath("$directory/$filename");
+
+  // Create the zip archive with all the files.
+  $zip = new ZipArchive();
+  $zip->open($zip_path, ZipArchive::CREATE);
+
+  foreach ($files as $file) {
+    $file_path = drupal_realpath($file);
+    $zip->addFile($file_path, "$zip_base/" . basename($file_path));
+  }
+
+  // @todo: Add any files from fields.
+
+  $zip->close();
+
+
+  // Send it to the client. Taken from:
+  // https://drupal.stackexchange.com/questions/33177/how-to-download-zip-file-through-browser
+  // Most of this is only necessary because of IE
+  header("Cache-Control: public");
+  header("Content-Type: application/octet-stream");
+  header("Cache-Control: no-store, no-cache, must-revalidate");
+  header("Cache-Control: post-check=0, pre-check=0");
+  header("Content-Disposition: attachment; filename=\"$filename\";" );
+  header("Content-Transfer-Encoding: binary");
+
+  $fp = fopen($zip_path, 'rb');
+  fpassthru($fp);
+
+  // Delete the directory, so that we don't have any dangling files with
+  // personal information.
+  file_unmanaged_delete_recursive($file_path);
 }
 
 /**
@@ -110,6 +156,16 @@ function gdpr_export_serialize_entity(EntityDrupalWrapper $entity, $type='xml', 
   $serializer = new Serializer($normalizers, $encoders);
 
   return $serializer->serialize($entity, $type);
+}
+
+/**
+ * Implements hook_gdpr_export_user_export().
+ */
+function gdpr_export_gdpr_export_user_export($account, $directory) {
+  // Export the basic user account data.
+  $meta = entity_metadata_wrapper('user', $account);
+  $data = gdpr_export_serialize_entity($meta);
+  return file_unmanaged_save_data($data, "$directory/user.xml");
 }
 
 /**

--- a/gdpr_export.module
+++ b/gdpr_export.module
@@ -59,10 +59,15 @@ function gdpr_export_user_export($account) {
   $directory = 'temporary://gdpr_export_' . $account->uid . '/' . REQUEST_TIME;
   file_prepare_directory($directory, FILE_CREATE_DIRECTORY);
 
+  $format = 'xml';
+  // Allow modules to alter the format. Currently only xml and json are
+  // supported.
+  drupal_alter('gdpr_export_user_export_format', $format);
+
   // Invoke all hooks that export user data. They should do that by saving a new
   // file into the given $directory and return the resulting filename
   // & path from as returned from file_unmanaged_save_data().
-  $files = module_invoke_all('gdpr_export_user_export', $account, $directory);
+  $files = module_invoke_all('gdpr_export_user_export', $account, $directory, $format);
 
   // Base name for the zip file and uncompressed folder.
   $zip_base = $account->uid . '_export';
@@ -167,11 +172,12 @@ function gdpr_export_serialize_entity(EntityDrupalWrapper $entity, $type='xml', 
 /**
  * Implements hook_gdpr_export_user_export().
  */
-function gdpr_export_gdpr_export_user_export($account, $directory) {
+function gdpr_export_gdpr_export_user_export($account, $directory, $format) {
   // Export the basic user account data.
   $meta = entity_metadata_wrapper('user', $account);
-  $data = gdpr_export_serialize_entity($meta);
-  return file_unmanaged_save_data($data, "$directory/user.xml");
+  $data = gdpr_export_serialize_entity($meta, $format);
+
+  return file_unmanaged_save_data($data, "$directory/user.$format");
 }
 
 /**

--- a/gdpr_export.module
+++ b/gdpr_export.module
@@ -50,7 +50,7 @@ function gdpr_export_user_export_access($account) {
 /**
  * Page callback to export a users data.
  *
- * @param \stdClass $account
+ * @param object $account
  *   The account for which the user should be exported.
  */
 function gdpr_export_user_export($account) {

--- a/gdpr_export.module
+++ b/gdpr_export.module
@@ -10,6 +10,52 @@ use Symfony\Component\Serializer\Serializer;
 use Symfony\Component\Serializer\Encoder\JsonEncoder;
 use Symfony\Component\Serializer\Encoder\XmlEncoder;
 
+/**
+ * Implements hook_menu().
+ */
+function gdpr_export_menu() {
+  $items['user/%user/gdpr_export_download'] = [
+    'title' => 'User data export',
+    'page callback' => 'gdpr_export_user_export',
+    'page arguments' => [1],
+    'access callback' => 'gdpr_export_user_export_access',
+    'access arguments' => [1],
+    'type' => MENU_CALLBACK,
+  ];
+  return $items;
+}
+
+/**
+ * Implements hook_permission().
+ */
+function gdpr_export_permission() {
+  return [
+    'bypass gdpr user export' => [
+      'title' => t('Access any user export'),
+      'description' => t('Allows users to access export data of any user.')
+    ]
+  ];
+}
+
+/**
+ * Access callback for the user export path.
+ */
+function gdpr_export_user_export_access($account) {
+  global $user;
+
+  return user_access('bypass gdpr user export', $user)
+    || $account->uid == $user->uid;
+}
+
+/**
+ * Page callback to export a users data.
+ *
+ * @param \stdClass $account
+ *   The account for which the user should be exported.
+ */
+function gdpr_export_user_export($account) {
+
+}
 
 /**
  * Returns a list of normalizers and their weight that can be used for the gdpr

--- a/gdpr_export.module
+++ b/gdpr_export.module
@@ -94,10 +94,10 @@ function gdpr_export_user_export($account) {
   }
 
   // Most of this is only necessary because of IE
-  drupal_add_http_header("Cache-Control: public, no-store, no-cache, must-revalidate, post-check=0, pre-check=0");
-  drupal_add_http_header("Content-Type: application/octet-stream");
-  drupal_add_http_header("Content-Disposition: attachment; filename=\"$filename\";" );
-  drupal_add_http_header("Content-Transfer-Encoding: binary");
+  drupal_add_http_header('Cache-Control', 'public, no-store, no-cache, must-revalidate, post-check=0, pre-check=0');
+  drupal_add_http_header('Content-Type',  'application/octet-stream');
+  drupal_add_http_header('Content-Disposition', "attachment; filename='$filename';" );
+  drupal_add_http_header('Content-Transfer-Encoding', 'binary');
 
   $fp = fopen($zip_path, 'rb');
   fpassthru($fp);


### PR DESCRIPTION
This PR implements a page callback to download all the exported data zipped. It also adds a button to the user edit page that redirects to that page. Not sure if this the right place though.

The page callback implements a new hook, that allows you to add new files. This new files can be either existing files or new exports. See the `hook_gdpr_export_user_export()` documentation on that.

I'm currently not sure if chosen paths in `gdpr_export_user_export()` are good, feedback on this would be greatly appreciated.