### PR TITLE
Implement file normalizer and download

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,3 @@
+*.module linguist-language=php
+*.install linguist-language=php
+*.info linguist-language=ini

--- a/gdpr_export.api.php
+++ b/gdpr_export.api.php
@@ -129,7 +129,7 @@ function hook_gdpr_export_user_export_format_alter(&$format) {
  *   the temp directory to which files copied or exported for zipping.
  */
 function hook_gdpr_export_user_export_context_alter(&$context) {
-  $context['some_context'] = 'context_value';
+  $context['gdpr_export_dir'] = 'some_other_dir';
 }
 
 /**

--- a/gdpr_export.api.php
+++ b/gdpr_export.api.php
@@ -92,16 +92,17 @@ function hook_gdpr_export_user_normalizer_alter(&$properties, $user_wrapper) {
  *
  * @param object $account
  *   The user account for which the data should be exported.
- * @param string $directory
- *   The directory where new files should be saved to.
  * @param string $format
  *   The format which should be used for the export. Currently only 'xml' and
  *   'json' are supported.
+ * @param array $context
+ *   An array of contexts. The default context gdpr_export_dir contains the temp
+ *   directory to which files copied or exported for zipping.
  *
  * @return bool|string
  *   A string with the path of the file to export, or FALSE on error.
  */
-function hook_gdpr_export_user_export($account, $directory, $format) {
+function hook_gdpr_export_user_export($account, $format, $context) {
   // Export a certain profile from the profile2 module. An appropriate profile2
   // would have to be implemented though.
   $profile = profile2_load_by_user($account, 'user_profile');
@@ -118,6 +119,19 @@ function hook_gdpr_export_user_export($account, $directory, $format) {
  */
 function hook_gdpr_export_user_export_format_alter(&$format) {
   $format = 'json';
+}
+
+/**
+ * Alter the contexts passed to the hook_gdpr_export_user_export()
+ * implementations and serializations. Encoders and normalizers will therefore
+ * be able to access those options.
+ *
+ * @param array $context
+ *   An array of contexts to alter. The default context gdpr_export_dir contains
+ *   the temp directory to which files copied or exported for zipping.
+ */
+function hook_gdpr_export_user_export_context_alter(&$context) {
+  $context['some_context'] = 'context_value';
 }
 
 /**

--- a/gdpr_export.api.php
+++ b/gdpr_export.api.php
@@ -80,15 +80,15 @@ function hook_gdpr_export_user_normalizer_alter(&$properties, $user_wrapper) {
 }
 
 /**
- * Allows to register new files to be exported with the user data.
+ * Allows to export files with the gdpr user export.
  *
  * If additional data should be exported, for example a profile or a node
  * related to the account, then modules should implement this hook.
- * New entities can be exported using gdpr_export_serialize_entity() and should
- * be saved to the $directory parameter using file_unmanaged_save_data(),
- * so that data is cleared after the files where zipped and downloaded.
- * If an existing file should be added to the export, than just return the path
- * to it.
+ * New entities can be exported using gdpr_export_serialize_entity() and have to
+ * be saved to the directory given in $context['gdpr_export_dir'] using
+ * file_unmanaged_save_data(). The function gdpr_export_user_export() will then
+ * zip all the files in $context['gdpr_export_dir'], send it to the client and
+ * remove the directory afterwards.
  *
  * @param object $account
  *   The user account for which the data should be exported.
@@ -98,17 +98,15 @@ function hook_gdpr_export_user_normalizer_alter(&$properties, $user_wrapper) {
  * @param array $context
  *   An array of contexts. The default context gdpr_export_dir contains the temp
  *   directory to which files copied or exported for zipping.
- *
- * @return bool|string
- *   A string with the path of the file to export, or FALSE on error.
  */
 function hook_gdpr_export_user_export($account, $format, $context) {
   // Export a certain profile from the profile2 module. An appropriate profile2
-  // would have to be implemented though.
+  // normalizer would have to be implemented though.
+  // @see GDPRExportEntityNormalizer.
   $profile = profile2_load_by_user($account, 'user_profile');
   $meta = entity_metadata_wrapper('profile2', $profile);
   $data = gdpr_export_serialize_entity($meta, $format);
-  return file_unmanaged_save_data($data, "$directory/user_profile.$format");
+  file_unmanaged_save_data($data, $context['gdpr_export_dir'] . "/user_profile.$format");
 }
 
 /**

--- a/gdpr_export.info
+++ b/gdpr_export.info
@@ -7,6 +7,7 @@ files[] = include/address_field_normalizer.inc
 files[] = include/date_normalizer.inc
 files[] = include/entity_normalizer.inc
 files[] = include/field_collection_item_normalizer.inc
+files[] = include/file_field_normalizer.inc
 files[] = include/generic_property_normalizer.inc
 files[] = include/image_field_normalizer.inc
 files[] = include/list_normalizer.inc

--- a/gdpr_export.info
+++ b/gdpr_export.info
@@ -8,6 +8,7 @@ files[] = include/date_normalizer.inc
 files[] = include/entity_normalizer.inc
 files[] = include/field_collection_item_normalizer.inc
 files[] = include/generic_property_normalizer.inc
+files[] = include/image_field_normalizer.inc
 files[] = include/list_normalizer.inc
 files[] = include/taxonomy_term_normalizer.inc
 files[] = include/user_normalizer.inc

--- a/gdpr_export.module
+++ b/gdpr_export.module
@@ -209,6 +209,7 @@ function gdpr_export_gdpr_export_normalizer_info() {
     'GDPRExportAddressFieldNormalizer' => -10,
     'GDPRExportDateNormalizer' => -5,
     'GDPRExportTaxonomyTermNormalizer' => 0,
+    'GDPRExportFileFieldNormalizer' => 0,
     'GDPRExportImageFieldNormalizer' => 0,
     'GDPRExportListNormalizer' => 0,
     'GDPRExportUserNormalizer' => 5,

--- a/gdpr_export.module
+++ b/gdpr_export.module
@@ -64,10 +64,13 @@ function gdpr_export_user_export($account) {
   // supported.
   drupal_alter('gdpr_export_user_export_format', $format);
 
+  $context = ['gdpr_export_dir' => $directory];
+  drupal_alter('gdpr_export_user_export_context', $directory);
+
   // Invoke all hooks that export user data. They should do that by saving a new
-  // file into the given $directory and return the resulting filename
-  // & path from as returned from file_unmanaged_save_data().
-  $files = module_invoke_all('gdpr_export_user_export', $account, $directory, $format);
+  // file into the given gdpr_export_dir set in the $context and return the
+  // resulting filename & path from as returned from file_unmanaged_save_data().
+  $files = module_invoke_all('gdpr_export_user_export', $account, $format, $context);
 
   // Base name for the zip file and uncompressed folder.
   $zip_base = $account->uid . '_export';
@@ -150,6 +153,8 @@ function gdpr_export_init_normalizers() {
  *   The entity to export.
  * @param string $type
  *   Type of export, either 'json' or 'xml' (default).
+ * @param array $context
+ *   Options normalizers/encoders have access to.
  * @param string $xml_root_name
  *   An optional name for the root node. If not set, it will be set to the
  *   entities type name. Only applicable if $type is 'xml'.
@@ -157,7 +162,7 @@ function gdpr_export_init_normalizers() {
  * @return string
  *   The serialized entity in the selected format, by default xml.
  */
-function gdpr_export_serialize_entity(EntityDrupalWrapper $entity, $type='xml', $xml_root_name = NULL) {
+function gdpr_export_serialize_entity(EntityDrupalWrapper $entity, $type = 'xml', $context = [], $xml_root_name = NULL) {
   if (empty($xml_root_name)) {
     $xml_root_name = $entity->type();
   }
@@ -166,18 +171,18 @@ function gdpr_export_serialize_entity(EntityDrupalWrapper $entity, $type='xml', 
   $encoders = [new JsonEncoder(), new XmlEncoder($xml_root_name)];
   $serializer = new Serializer($normalizers, $encoders);
 
-  return $serializer->serialize($entity, $type);
+  return $serializer->serialize($entity, $type, $context);
 }
 
 /**
  * Implements hook_gdpr_export_user_export().
  */
-function gdpr_export_gdpr_export_user_export($account, $directory, $format) {
+function gdpr_export_gdpr_export_user_export($account, $format, $context) {
   // Export the basic user account data.
   $meta = entity_metadata_wrapper('user', $account);
-  $data = gdpr_export_serialize_entity($meta, $format);
+  $data = gdpr_export_serialize_entity($meta, $format, $context);
 
-  return file_unmanaged_save_data($data, "$directory/user.$format");
+  return file_unmanaged_save_data($data, $context['gdpr_export_dir'] . "/user.$format");
 }
 
 /**

--- a/gdpr_export.module
+++ b/gdpr_export.module
@@ -83,8 +83,10 @@ function gdpr_export_user_export($account) {
   $zip = new ZipArchive();
   $zip->open($zip_path, ZipArchive::CREATE);
 
+  // Get the path to export directory.
   $real_dir = drupal_realpath($directory);
 
+  // Get a list of all files in the export dir.
   $files = new RecursiveIteratorIterator(
     new RecursiveDirectoryIterator($real_dir),
     RecursiveIteratorIterator::LEAVES_ONLY
@@ -92,26 +94,24 @@ function gdpr_export_user_export($account) {
 
   foreach ($files as $name => $file)
   {
-    // Skip directories (they would be added automatically)
+    // Skip directories (they will be added automatically)
     if (!$file->isDir())
     {
       // Get real and relative path for current file
       $filePath = $file->getRealPath();
       $relativePath = substr($filePath, strlen($real_dir) + 1);
 
-      // Add current file to archive
+      // Add current file to archive, keep the realtive path though, since they
+      // are referenced in the export by the file normalizers.
       $zip->addFile($filePath, $relativePath);
     }
   }
-
-  // @todo: Add any files from fields.
 
   $zip->close();
 
   // Send it to the client. Taken from:
   // https://drupal.stackexchange.com/questions/33177/how-to-download-zip-file-through-browser
   // and @see file_transfer().
-
   if (ob_get_level()) {
     ob_end_clean();
   }
@@ -127,7 +127,7 @@ function gdpr_export_user_export($account) {
   fclose($fp);
 
   // Delete the directory, so that we don't have any dangling files with
-  // personal information.
+  // personal information in the temp dir.
   file_unmanaged_delete_recursive($directory);
   drupal_exit();
 }

--- a/gdpr_export.module
+++ b/gdpr_export.module
@@ -92,11 +92,9 @@ function gdpr_export_user_export($account) {
     RecursiveIteratorIterator::LEAVES_ONLY
   );
 
-  foreach ($files as $name => $file)
-  {
+  foreach ($files as $name => $file) {
     // Skip directories (they will be added automatically)
-    if (!$file->isDir())
-    {
+    if (!$file->isDir()) {
       // Get real and relative path for current file
       $filePath = $file->getRealPath();
       $relativePath = substr($filePath, strlen($real_dir) + 1);
@@ -118,8 +116,8 @@ function gdpr_export_user_export($account) {
 
   // Most of this is only necessary because of IE
   drupal_add_http_header('Cache-Control', 'public, no-store, no-cache, must-revalidate, post-check=0, pre-check=0');
-  drupal_add_http_header('Content-Type',  'application/octet-stream');
-  drupal_add_http_header('Content-Disposition', "attachment; filename=$filename;" );
+  drupal_add_http_header('Content-Type', 'application/octet-stream');
+  drupal_add_http_header('Content-Disposition', "attachment; filename=$filename;");
   drupal_add_http_header('Content-Transfer-Encoding', 'binary');
 
   $fp = fopen($zip_path, 'rb');

--- a/gdpr_export.module
+++ b/gdpr_export.module
@@ -75,6 +75,7 @@ function gdpr_export_gdpr_export_normalizer_info() {
     'GDPRExportAddressFieldNormalizer' => -10,
     'GDPRExportDateNormalizer' => -5,
     'GDPRExportTaxonomyTermNormalizer' => 0,
+    'GDPRExportImageFieldNormalizer' => 0,
     'GDPRExportListNormalizer' => 0,
     'GDPRExportUserNormalizer' => 5,
     'GDPRExportFieldCollectionItemNormalizer' => 5,

--- a/gdpr_export.module
+++ b/gdpr_export.module
@@ -70,7 +70,7 @@ function gdpr_export_user_export($account) {
   // Invoke all hooks that export user data. They should do that by saving a new
   // file into the given gdpr_export_dir set in the $context and return the
   // resulting filename & path from as returned from file_unmanaged_save_data().
-  $files = module_invoke_all('gdpr_export_user_export', $account, $format, $context);
+  module_invoke_all('gdpr_export_user_export', $account, $format, $context);
 
   // Base name for the zip file and uncompressed folder.
   $zip_base = $account->uid . '_export';
@@ -197,7 +197,7 @@ function gdpr_export_gdpr_export_user_export($account, $format, $context) {
   $meta = entity_metadata_wrapper('user', $account);
   $data = gdpr_export_serialize_entity($meta, $format, $context);
 
-  return file_unmanaged_save_data($data, $context['gdpr_export_dir'] . "/user.$format");
+  file_unmanaged_save_data($data, $context['gdpr_export_dir'] . "/user.$format");
 }
 
 /**

--- a/gdpr_export.module
+++ b/gdpr_export.module
@@ -82,27 +82,3 @@ function gdpr_export_gdpr_export_normalizer_info() {
     'GDPRExportGenericDataNormalizer' => 5,
   ];
 }
-
-/**
- * Register a managed file that should be sent with the export and return them.
- *
- * @param integer|null $fid
- *   The optional managed file id, to be added to the export. If not set, then
- *   the function will return the file ids that have been added so far.
- *
- * @return array
- *   The file ids, which should be added to export in an array.
- */
-function gdpr_export_register_file_for_export($fid = NULL) {
-  $data = &drupal_static(__FUNCTION__);
-  if (empty($data)) {
-    $data = [];
-  }
-
-  // Only add the passed file id if it's not NULL and not in the array yet.
-  if ($fid !== NULL && !in_array($fid, $data)) {
-    $data[] = $fid;
-  }
-
-  return $data;
-}

--- a/gdpr_export.module
+++ b/gdpr_export.module
@@ -83,15 +83,30 @@ function gdpr_export_user_export($account) {
   $zip = new ZipArchive();
   $zip->open($zip_path, ZipArchive::CREATE);
 
-  foreach ($files as $file) {
-    $file_path = drupal_realpath($file);
-    $zip->addFile($file_path, "$zip_base/" . basename($file_path));
+  $real_dir = drupal_realpath($directory);
+
+  $files = new RecursiveIteratorIterator(
+    new RecursiveDirectoryIterator($real_dir),
+    RecursiveIteratorIterator::LEAVES_ONLY
+  );
+
+  foreach ($files as $name => $file)
+  {
+    // Skip directories (they would be added automatically)
+    if (!$file->isDir())
+    {
+      // Get real and relative path for current file
+      $filePath = $file->getRealPath();
+      $relativePath = substr($filePath, strlen($real_dir) + 1);
+
+      // Add current file to archive
+      $zip->addFile($filePath, $relativePath);
+    }
   }
 
   // @todo: Add any files from fields.
 
   $zip->close();
-
 
   // Send it to the client. Taken from:
   // https://drupal.stackexchange.com/questions/33177/how-to-download-zip-file-through-browser
@@ -113,7 +128,7 @@ function gdpr_export_user_export($account) {
 
   // Delete the directory, so that we don't have any dangling files with
   // personal information.
-  file_unmanaged_delete_recursive($file_path);
+  file_unmanaged_delete_recursive($directory);
   drupal_exit();
 }
 

--- a/gdpr_export.module
+++ b/gdpr_export.module
@@ -222,7 +222,7 @@ function gdpr_export_gdpr_export_normalizer_info() {
  * Implements hook_form_FORM_ID_alter().
  */
 function gdpr_export_form_user_profile_form_alter(&$form, &$form_state, $form_id) {
-  // @todo: does it makes sense to place the export link in the edit form.
+  // @todo: does it makes sense to place the export link in the edit form?
   global $user;
   $account_uid = $form['#user']->uid;
 
@@ -237,6 +237,9 @@ function gdpr_export_form_user_profile_form_alter(&$form, &$form_state, $form_id
   }
 }
 
+/**
+ * Submit callback for the gdpr export button on the user edit form.
+ */
 function gdpr_export_user_data_submit(&$form, &$form_state) {
   drupal_goto('user/' . $form['#user']->uid . '/gdpr_export');
 }

--- a/gdpr_export.module
+++ b/gdpr_export.module
@@ -81,3 +81,27 @@ function gdpr_export_gdpr_export_normalizer_info() {
     'GDPRExportGenericDataNormalizer' => 5,
   ];
 }
+
+/**
+ * Register a managed file that should be sent with the export and return them.
+ *
+ * @param integer|null $fid
+ *   The optional managed file id, to be added to the export. If not set, then
+ *   the function will return the file ids that have been added so far.
+ *
+ * @return array
+ *   The file ids, which should be added to export in an array.
+ */
+function gdpr_export_register_file_for_export($fid = NULL) {
+  $data = &drupal_static(__FUNCTION__);
+  if (empty($data)) {
+    $data = [];
+  }
+
+  // Only add the passed file id if it's not NULL and not in the array yet.
+  if ($fid !== NULL && !in_array($fid, $data)) {
+    $data[] = $fid;
+  }
+
+  return $data;
+}

--- a/include/address_field_normalizer.inc
+++ b/include/address_field_normalizer.inc
@@ -21,7 +21,7 @@ class GDPRExportAddressFieldNormalizer implements NormalizerInterface {
     // addressfield_autocomplete module.
     $address = array_filter($address, function ($value, $key) {
       return !empty($value) && $key != 'data';
-    }, ARRAY_FILTER_USE_BOTH );
+    }, ARRAY_FILTER_USE_BOTH);
 
     return $address;
   }

--- a/include/date_normalizer.inc
+++ b/include/date_normalizer.inc
@@ -6,6 +6,7 @@
  */
 
 use \Symfony\Component\Serializer\Normalizer\NormalizerInterface;
+
 /**
  * A data formatter for date columns.
  */

--- a/include/entity_normalizer.inc
+++ b/include/entity_normalizer.inc
@@ -53,12 +53,19 @@ abstract class GDPRExportEntityNormalizer implements NormalizerInterface, Normal
 
   /**
    * Returns all normalized fields of the given entity
+
+   * @param object $object
+   *   Object to normalize
+   * @param string $format
+   *   Format the normalization result will be encoded as
+   * @param array $context
+   *   Context options for the normalizer
    *
-   * @return array
+   * @return array|scalar
    *   An array containing the the normalized field values, keyed by the field
    *   names.
    */
-  protected function getNormalizedFields($object) {
+  protected function getNormalizedFields($object, $format = NULL, array $context = array()) {
     // Get all fields names.
     $field_names = array_keys(field_info_instances($object->type(),
       $object->getBundle()));
@@ -67,7 +74,7 @@ abstract class GDPRExportEntityNormalizer implements NormalizerInterface, Normal
     // Normalize and save it to the results array keyed by the field name.
     foreach ($field_names as $field_name) {
       try {
-        $result[$field_name] = $this->normalizer->normalize($object->$field_name);
+        $result[$field_name] = $this->normalizer->normalize($object->$field_name, $format, $context);
       }
       catch (NotNormalizableValueException $exception) {
         watchdog_exception('gdpr_export', $exception);

--- a/include/entity_normalizer.inc
+++ b/include/entity_normalizer.inc
@@ -53,7 +53,6 @@ abstract class GDPRExportEntityNormalizer implements NormalizerInterface, Normal
 
   /**
    * Returns all normalized fields of the given entity
-
    * @param object $object
    *   Object to normalize
    * @param string $format

--- a/include/field_collection_item_normalizer.inc
+++ b/include/field_collection_item_normalizer.inc
@@ -17,7 +17,7 @@ class GDPRExportFieldCollectionItemNormalizer extends GDPRExportEntityNormalizer
   public function normalize($object, $format = NULL, array $context = array()) {
     // In most cases it will be enough to export the fields of a field
     // collection item.
-    $result = $this->getNormalizedFields($object);
+    $result = $this->getNormalizedFields($object, $format, $context);
 
     // Allow modules to alter the fields to export based on the entity meta data
     // wrapper.

--- a/include/file_field_normalizer.inc
+++ b/include/file_field_normalizer.inc
@@ -1,0 +1,48 @@
+<?php
+
+/**
+ * @file
+ * Provides the file field normalizer.
+ */
+
+use \Symfony\Component\Serializer\Normalizer\NormalizerInterface;
+
+/**
+ * Implements a normalizer for file fields, which also copies to the
+ * gdpr_export_dir if it was given in the context.
+ */
+class GDPRExportFileFieldNormalizer implements NormalizerInterface {
+  /**
+   * @inheritdoc
+   */
+  public function normalize($object, $format = NULL, array $context = array()) {
+    $file = $object->value();
+
+    // Check if the export directory was passed to the context and if that
+    // directory exists.
+    if (!empty($context['gdpr_export_dir']) && file_prepare_directory($context['gdpr_export_dir'])) {
+      // Copy the file to the export dir, so that it gets zipped with the
+      // export.
+      // The target directory should be the directory with out the scheme, so
+      // that we don't accidentally replace files, or have to handle suffixes on
+      // the filename.
+      $target = $context['gdpr_export_dir'] . "/" . file_uri_target($file['uri']);
+      $dir = dirname($target);
+      file_prepare_directory($dir, FILE_CREATE_DIRECTORY);
+      file_unmanaged_copy($file['uri'], $target);
+    }
+
+    return [
+      'filename' => $file['filename'],
+      'path' => file_uri_target($file['uri']),
+    ];
+  }
+
+  /**
+   * @inheritdoc
+   */
+  public function supportsNormalization($data, $format = NULL) {
+    return $data instanceof EntityStructureWrapper
+      && $data->info()['type'] == 'field_item_file';
+  }
+}

--- a/include/image_field_normalizer.inc
+++ b/include/image_field_normalizer.inc
@@ -8,33 +8,29 @@
 use \Symfony\Component\Serializer\Normalizer\NormalizerInterface;
 
 /**
- * Implements a normalizer for image fields.
+ * Implements a normalizer for image fields, based on the
+ * GDPRExportFileFieldNormalizer, adding the 'title' property if available.
  */
-class GDPRExportImageFieldNormalizer implements NormalizerInterface {
+class GDPRExportImageFieldNormalizer extends GDPRExportFileFieldNormalizer {
+  /**
+   * @inheritdoc
+   */
   public function normalize($object, $format = NULL, array $context = array()) {
     $file = $object->value();
 
-    // Check if the export directory was passed to the context and if that
-    // directory exists.
-    if (!empty($context['gdpr_export_dir']) && file_prepare_directory($context['gdpr_export_dir'])) {
-      // Copy the file to the export dir, so that it gets zipped with the
-      // export.
-      // The target directory should be the directory with out the scheme, so
-      // that we don't accidentally replace files, or have to handle suffixes on
-      // the filename.
-      $target = $context['gdpr_export_dir'] . "/" . file_uri_target($file['uri']);
-      $dir = dirname($target);
-      file_prepare_directory($dir, FILE_CREATE_DIRECTORY);
-      file_unmanaged_copy($file['uri'], $target);
+    $result = parent::normalize($object, $format, $context);
+
+    // Add the title if not empty.
+    if (!empty($result['title'])) {
+      $result['title'] = $file['title'];
     }
 
-    return [
-      'title' => $file['title'],
-      'filename' => file_uri_target($file['uri']),
-      'path' => file_uri_target($file['uri']),
-    ];
+    return $result;
   }
 
+  /**
+   * @inheritdoc
+   */
   public function supportsNormalization($data, $format = NULL) {
     return $data instanceof EntityStructureWrapper
       && $data->info()['type'] == 'field_item_image';

--- a/include/image_field_normalizer.inc
+++ b/include/image_field_normalizer.inc
@@ -14,6 +14,8 @@ class GDPRExportImageFieldNormalizer implements NormalizerInterface {
   public function normalize($object, $format = NULL, array $context = array()) {
     $file = $object->value();
 
+    gdpr_export_register_file_for_export($file['fid']);
+
     return [
       'title' => $file['title'],
       'filename' => $file['filename'],

--- a/include/image_field_normalizer.inc
+++ b/include/image_field_normalizer.inc
@@ -14,8 +14,6 @@ class GDPRExportImageFieldNormalizer implements NormalizerInterface {
   public function normalize($object, $format = NULL, array $context = array()) {
     $file = $object->value();
 
-    gdpr_export_register_file_for_export($file['fid']);
-
     return [
       'title' => $file['title'],
       'filename' => $file['filename'],

--- a/include/image_field_normalizer.inc
+++ b/include/image_field_normalizer.inc
@@ -1,0 +1,29 @@
+<?php
+
+/**
+ * @file
+ * Provides the image field normalizer.
+ */
+
+use \Symfony\Component\Serializer\Normalizer\NormalizerInterface;
+
+/**
+ * Implements a normalizer for image fields.
+ */
+class GDPRExportImageFieldNormalizer implements NormalizerInterface {
+  public function normalize($object, $format = NULL, array $context = array()) {
+    $file = $object->value();
+
+    return [
+      'title' => $file['title'],
+      'filename' => $file['filename'],
+      'path' => file_uri_target($file['uri']),
+    ];
+  }
+
+  public function supportsNormalization($data, $format = NULL) {
+    return $data instanceof EntityStructureWrapper
+      && $data->info()['type'] == 'field_item_image';
+  }
+
+}

--- a/include/image_field_normalizer.inc
+++ b/include/image_field_normalizer.inc
@@ -14,9 +14,23 @@ class GDPRExportImageFieldNormalizer implements NormalizerInterface {
   public function normalize($object, $format = NULL, array $context = array()) {
     $file = $object->value();
 
+    // Check if the export directory was passed to the context and if that
+    // directory exists.
+    if (!empty($context['gdpr_export_dir']) && file_prepare_directory($context['gdpr_export_dir'])) {
+      // Copy the file to the export dir, so that it gets zipped with the
+      // export.
+      // The target directory should be the directory with out the scheme, so
+      // that we don't accidentally replace files, or have to handle suffixes on
+      // the filename.
+      $target = $context['gdpr_export_dir'] . "/" . file_uri_target($file['uri']);
+      $dir = dirname($target);
+      file_prepare_directory($dir, FILE_CREATE_DIRECTORY);
+      file_unmanaged_copy($file['uri'], $target);
+    }
+
     return [
       'title' => $file['title'],
-      'filename' => $file['filename'],
+      'filename' => file_uri_target($file['uri']),
       'path' => file_uri_target($file['uri']),
     ];
   }
@@ -25,5 +39,4 @@ class GDPRExportImageFieldNormalizer implements NormalizerInterface {
     return $data instanceof EntityStructureWrapper
       && $data->info()['type'] == 'field_item_image';
   }
-
 }

--- a/include/list_normalizer.inc
+++ b/include/list_normalizer.inc
@@ -24,7 +24,7 @@ class GDPRExportListNormalizer implements NormalizerInterface, NormalizerAwareIn
 
     $result = [];
     foreach ($object as $item) {
-      $result[] = $this->normalizer->normalize($item);
+      $result[] = $this->normalizer->normalize($item, $format, $context);
     }
     return $result;
   }

--- a/include/taxonomy_term_normalizer.inc
+++ b/include/taxonomy_term_normalizer.inc
@@ -18,7 +18,8 @@ class GDPRExportTaxonomyTermNormalizer implements NormalizerInterface {
   public function normalize($object, $format = NULL, array $context = array()) {
     try {
       return $object->name->value();
-    } catch (EntityMetadataWrapperException $exception) {
+    }
+    catch (EntityMetadataWrapperException $exception) {
       watchdog_exception('gdpr_export', $exception);
       return '';
     }

--- a/include/user_normalizer.inc
+++ b/include/user_normalizer.inc
@@ -6,8 +6,18 @@
 class GDPRExportUserNormalizer extends GDPRExportEntityNormalizer {
   /**
    * Returns the normalized basic user properties, i.e. the basic user columns.
+   *
+   * @param object $object
+   *   Object to normalize
+   * @param string $format
+   *   Format the normalization result will be encoded as
+   * @param array $context
+   *   Context options for the normalizer
+   *
+   * @return array|scalar
+   *   The normalized $object.
    */
-  protected function getBasicProperties($object) {
+  protected function getBasicProperties($object, $format = NULL, array $context = array()) {
     // @todo: Check that this are really the default drupal core properties.
     // @todo: Add language as the appropriate normalizer is ready.
     $properties = [
@@ -22,15 +32,18 @@ class GDPRExportUserNormalizer extends GDPRExportEntityNormalizer {
 
     $normalized = [];
     foreach ($properties as $property) {
-      $normalized[$property] = $this->normalizer->normalize($object->$property);
+      $normalized[$property] = $this->normalizer->normalize($object->$property, $format, $context);
     }
 
     return $normalized;
   }
 
+  /**
+   * @inheritdoc
+   */
   public function normalize($object, $format = NULL, array $context = array()) {
-    $result = $this->getBasicProperties($object);
-    $result += $this->getNormalizedFields($object);
+    $result = $this->getBasicProperties($object, $format, $context);
+    $result += $this->getNormalizedFields($object, $format, $context);
 
     // Allow modules to add or remove properties
     drupal_alter('gdpr_export_user_normalizer', $result, $object);


### PR DESCRIPTION
This PR adds normalizers for managed file and image fields, which also copy the referenced files to the temporary export directory, so that they are zipped with the rest of the export.

To provide the directory where the files should be copied to, I had to rewrite the existing functions. `hook_gdpr_export_user_export()` implementations now accept a `$context` parameter instead of the export directory, so that more options can be passed to those functions. They also can be passed to the serializer and the default context from the `gdpr_export_user_export()` function can be altered.