### PR TITLE
Add alter hook to control if field of entity should be exported.

### DIFF
--- a/gdpr_export.api.php
+++ b/gdpr_export.api.php
@@ -53,6 +53,23 @@ function hook_gdpr_export_normalizer_info_alter(&$normalizers) {
 }
 
 /**
+ * Alter if the field of an entity should be exported.
+ *
+ * @param bool $should_export
+ *   True if the field should be exported, false if not.
+ * @param array $context
+ *   An array containing the name of the field to be exported in the key
+ *  'field_name' and the entity that contains this field in the key 'entity'
+ */
+function hook_gdpr_export_entity_should_export_field_alter(&$should_export, $context) {
+  if ($context['entity']->type == 'user'
+    && $context['field_name'] == 'field_user_contacts')
+  {
+    $should_export = FALSE;
+  }
+}
+
+/**
  * Alter the fields that the field collection normalizer should return.
  *
  * @param array $fields

--- a/gdpr_export.api.php
+++ b/gdpr_export.api.php
@@ -55,17 +55,14 @@ function hook_gdpr_export_normalizer_info_alter(&$normalizers) {
 /**
  * Alter if the field of an entity should be exported.
  *
- * @param bool $should_export
- *   True if the field should be exported, false if not.
- * @param array $context
- *   An array containing the name of the field to be exported in the key
- *  'field_name' and the entity that contains this field in the key 'entity'
+ * @param array $field_names
+ *   The names of fields that should be exported.
+ * @param \EntityDrupalWrapper $entity_metadata
+ *   The entity meta data wrapper for which the fields should be exported.
  */
-function hook_gdpr_export_entity_should_export_field_alter(&$should_export, $context) {
-  if ($context['entity']->type == 'user'
-    && $context['field_name'] == 'field_user_contacts')
-  {
-    $should_export = FALSE;
+function hook_gdpr_export_entity_fields_alter(&$field_names, $entity_metadata) {
+  if ($entity_metadata->type() == 'user') {
+    $field_names = array_diff($field_names, ['field_user_contacts']);
   }
 }
 

--- a/include/address_field_normalizer.inc
+++ b/include/address_field_normalizer.inc
@@ -19,9 +19,11 @@ class GDPRExportAddressFieldNormalizer implements NormalizerInterface {
 
     // Remove empty values and the data key, added by the
     // addressfield_autocomplete module.
-    $address = array_filter($address, function ($value, $key) {
-      return !empty($value) && $key != 'data';
-    }, ARRAY_FILTER_USE_BOTH);
+    if (!empty($address)) {
+      $address = array_filter($address, function ($value, $key) {
+        return !empty($value) && $key != 'data';
+      }, ARRAY_FILTER_USE_BOTH);
+    }
 
     return $address;
   }

--- a/include/date_normalizer.inc
+++ b/include/date_normalizer.inc
@@ -15,7 +15,8 @@ class GDPRExportDateNormalizer implements NormalizerInterface {
    * @inheritdoc
    */
   public function normalize($object, $format = NULL, array $context = array()) {
-    return format_date($object->value());
+    // Export the date in the ISO 8601 format.
+    return date('c', $object->value());
   }
 
   /**

--- a/include/entity_normalizer.inc
+++ b/include/entity_normalizer.inc
@@ -73,7 +73,20 @@ abstract class GDPRExportEntityNormalizer implements NormalizerInterface, Normal
     // Normalize and save it to the results array keyed by the field name.
     foreach ($field_names as $field_name) {
       try {
-        $result[$field_name] = $this->normalizer->normalize($object->$field_name, $format, $context);
+        // Allow modules to alter if a field should be exported or not. This is
+        // especially important for preventing recursions in case there entity
+        // references pointing at each other, like a friends list or similar.
+        // By default we export all fields.
+        $should_export = TRUE;
+        $context = [
+          'field_name' => $field_name,
+          'entity' => $object
+        ];
+        drupal_alter('gdpr_export_entity_should_export_field', $should_export, $context);
+
+        if ($should_export) {
+          $result[$field_name] = $this->normalizer->normalize($object->$field_name, $format, $context);
+        }
       }
       catch (NotNormalizableValueException $exception) {
         watchdog_exception('gdpr_export', $exception);

--- a/include/entity_normalizer.inc
+++ b/include/entity_normalizer.inc
@@ -70,6 +70,10 @@ abstract class GDPRExportEntityNormalizer implements NormalizerInterface, Normal
       $object->getBundle()));
 
     $result = [];
+
+
+    drupal_alter('gdpr_export_entity_fields', $field_names, $object);
+
     // Normalize and save it to the results array keyed by the field name.
     foreach ($field_names as $field_name) {
       try {
@@ -77,16 +81,7 @@ abstract class GDPRExportEntityNormalizer implements NormalizerInterface, Normal
         // especially important for preventing recursions in case there entity
         // references pointing at each other, like a friends list or similar.
         // By default we export all fields.
-        $should_export = TRUE;
-        $context = [
-          'field_name' => $field_name,
-          'entity' => $object
-        ];
-        drupal_alter('gdpr_export_entity_should_export_field', $should_export, $context);
-
-        if ($should_export) {
-          $result[$field_name] = $this->normalizer->normalize($object->$field_name, $format, $context);
-        }
+        $result[$field_name] = $this->normalizer->normalize($object->$field_name, $format, $context);
       }
       catch (NotNormalizableValueException $exception) {
         watchdog_exception('gdpr_export', $exception);

--- a/include/entity_normalizer.inc
+++ b/include/entity_normalizer.inc
@@ -71,16 +71,12 @@ abstract class GDPRExportEntityNormalizer implements NormalizerInterface, Normal
 
     $result = [];
 
-
+    // Allow modules to change the fields to be exported.
     drupal_alter('gdpr_export_entity_fields', $field_names, $object);
 
     // Normalize and save it to the results array keyed by the field name.
     foreach ($field_names as $field_name) {
       try {
-        // Allow modules to alter if a field should be exported or not. This is
-        // especially important for preventing recursions in case there entity
-        // references pointing at each other, like a friends list or similar.
-        // By default we export all fields.
         $result[$field_name] = $this->normalizer->normalize($object->$field_name, $format, $context);
       }
       catch (NotNormalizableValueException $exception) {

--- a/include/entity_normalizer.inc
+++ b/include/entity_normalizer.inc
@@ -53,7 +53,7 @@ abstract class GDPRExportEntityNormalizer implements NormalizerInterface, Normal
 
   /**
    * Returns all normalized fields of the given entity
-   * @param object $object
+   * @param \EntityDrupalWrapper $object
    *   Object to normalize
    * @param string $format
    *   Format the normalization result will be encoded as

--- a/include/entity_normalizer.inc
+++ b/include/entity_normalizer.inc
@@ -64,7 +64,7 @@ abstract class GDPRExportEntityNormalizer implements NormalizerInterface, Normal
    *   An array containing the the normalized field values, keyed by the field
    *   names.
    */
-  protected function getNormalizedFields($object, $format = NULL, array $context = array()) {
+  protected function getNormalizedFields(EntityDrupalWrapper $object, $format = NULL, array $context = array()) {
     // Get all fields names.
     $field_names = array_keys(field_info_instances($object->type(),
       $object->getBundle()));


### PR DESCRIPTION
This PR adds a new alter hook, which allows you to control if a field of an entity should be exported or not. This is usefull for fields, that contain information of other users or to prevent recursions.