### PR TITLE
Fix generic property normalizer not working for formatted texts.

### DIFF
--- a/include/generic_property_normalizer.inc
+++ b/include/generic_property_normalizer.inc
@@ -24,7 +24,7 @@ class GDPRExportGenericDataNormalizer implements NormalizerInterface {
    */
   public function supportsNormalization($data, $format = NULL) {
     // @todo: Add additional formats like float
-    return $data instanceof EntityValueWrapper
+    return $data instanceof EntityMetadataWrapper
       && in_array($data->info()['type'],
         ['text', 'integer', 'text_formatted', 'boolean', 'uri' , 'decimal']);
   }


### PR DESCRIPTION
This PR fixes the generic property normalizer to exporting formatted texts. As mentioned in #6 , the Generic Property Normalizer checks for a `EntityValueWrapper`, but `text_formatted` properties use `EntityStructureWrapper`. To fix that issue, the normalizer now checks for the parent class `EntityMetadataWrapper`. This seems to work well, since it exports all properties:
```
<body>
  <value><p>test solli</p></value>
  <summary/>
  <format>filtered_html</format>
  <safe_value><p>test solli</p></safe_value>
  <safe_summary/>
</body>
```

Alternatively we could implement a separate normalizer for this property, but I'm not sure if its worth.