### PR TITLE
Add module to export privatemsg messages.

### DIFF
--- a/modules/gdpr_export_privatemsg/gdpr_export_privatemsg.info
+++ b/modules/gdpr_export_privatemsg/gdpr_export_privatemsg.info
@@ -1,0 +1,7 @@
+name = GDPR export privatemsg
+description = This module adds support to export messages from privatemsg for gdpr_export
+core = 7.x
+package = General Data Protection Regulation
+dependencies[] = gdpr_export
+dependencies[] = privatemsg
+files[] = includes/privatemsg_message.inc

--- a/modules/gdpr_export_privatemsg/gdpr_export_privatemsg.module
+++ b/modules/gdpr_export_privatemsg/gdpr_export_privatemsg.module
@@ -1,0 +1,35 @@
+<?php
+
+/**
+ * @file
+ * Code for the GDPR export privatemsg module.
+ */
+
+/**
+ * Implements hook_gdpr_export_user_export().
+ */
+function gdpr_export_privatemsg_gdpr_export_user_export($account, $format, $context) {
+  $query = new EntityFieldQuery();
+
+  // Query all messages which were created by the user.
+  $result = $query->entityCondition('entity_type', 'privatemsg_message')
+    ->propertyCondition('author', $account->uid)
+    ->execute();
+
+  if (!empty($result['privatemsg_message'])) {
+    foreach ($result['privatemsg_message'] as $mid => $message) {
+      $message = entity_metadata_wrapper('privatemsg_message', $mid);
+      $data = gdpr_export_serialize_entity($message, $format, $context);
+      file_unmanaged_save_data($data, $context['gdpr_export_dir'] . "/privatemsg_message_$mid.$format");
+    }
+  }
+}
+
+/**
+ * Implements hook_gdpr_export_normalizer_info().
+ */
+function gdpr_export_privatemsg_gdpr_export_normalizer_info() {
+  return [
+    'GDPRExportPrivatemsgMessage' => 0,
+  ];
+}

--- a/modules/gdpr_export_privatemsg/includes/privatemsg_message.inc
+++ b/modules/gdpr_export_privatemsg/includes/privatemsg_message.inc
@@ -1,0 +1,38 @@
+<?php
+
+/**
+ * Provides a class to normalize Privatemsg messages.
+ */
+
+/**
+ * Normalizes Privatemsg messages.
+ */
+class GDPRExportPrivatemsgMessage extends GDPRExportEntityNormalizer {
+  public function normalize($object, $format = NULL, array $context = array()) {
+    $properties = [
+      'timestamp',
+      'subject',
+      'body',
+    ];
+
+    $export = [];
+    foreach ($properties as $property) {
+      $export[$property] = $this->normalizer->normalize($object->$property, $format, $context);
+    }
+
+    // Non serializable properties.
+    $plain_properties = [
+      'format',
+      'is_new',
+    ];
+    foreach ($plain_properties as $property) {
+      $export[$properties] = $this->$property;
+    }
+
+    return $export;
+  }
+
+  public function supportsNormalization($data, $format = NULL) {
+    return $this->isEntityType($data, 'privatemsg_message');
+  }
+}


### PR DESCRIPTION
This PR adds a module to export messages from the privatemsg module. Only private messages which where created by the user are exported, but no replies or other messages in a thread. This would otherwise violate the rights of users.