### PR TITLE
Add support to export organic groups.

### DIFF
--- a/modules/gdpr_export_og/gdpr_export_og.info
+++ b/modules/gdpr_export_og/gdpr_export_og.info
@@ -1,0 +1,7 @@
+name = GDPR export OG
+description = This module adds support for gdpr_export support to organic groups.
+core = 7.x
+package = General Data Protection Regulation
+dependencies[] = gdpr_export
+dependencies[] = og
+files[] = include/og_normalizer.inc

--- a/modules/gdpr_export_og/gdpr_export_og.module
+++ b/modules/gdpr_export_og/gdpr_export_og.module
@@ -1,0 +1,37 @@
+<?php
+
+/**
+ * @file
+ * Code for the GDPR export profile2 module.
+ */
+
+/**
+ * Implements hook_gdpr_export_user_export().
+ */
+function gdpr_export_og_gdpr_export_user_export($account, $format, $context) {
+  // Add all profile bundles to the export.
+  $query = new EntityFieldQuery();
+
+  $result = $query->entityCondition('entity_type', 'og_membership')
+    ->propertyCondition('entity_type', 'user')
+    ->propertyCondition('etid', $account->uid)
+    ->execute();
+
+  if (isset($result['og_membership'])) {
+    foreach ($result['og_membership'] as $id => $item) {
+      $membership = entity_metadata_wrapper('og_membership', $id);
+      $data = gdpr_export_serialize_entity($membership, $format, $context);
+      file_unmanaged_save_data($data, $context['gdpr_export_dir'] . "/organic_groups_$id.$format");
+    }
+  }
+
+}
+
+/**
+ * Implements hook_gdpr_export_normalizer_info().
+ */
+function gdpr_export_og_gdpr_export_normalizer_info() {
+  return [
+    GDPRExportOGNormalizer => 2
+  ];
+}

--- a/modules/gdpr_export_og/include/og_normalizer.inc
+++ b/modules/gdpr_export_og/include/og_normalizer.inc
@@ -1,0 +1,50 @@
+<?php
+
+/**
+ * Provides a normalizer for organic groups.
+ */
+class GDPRExportOGNormalizer extends GDPRExportEntityNormalizer {
+
+  /**
+   * Normalize Profile object.
+   *
+   * @inheritdoc
+   */
+  public function normalize($object, $format = NULL, array $context = array()) {
+    $membership = $object->raw();
+
+    $group_entity = entity_metadata_wrapper($membership->group_type, $membership->gid);
+
+    $result['label'] = $group_entity->label();
+    $result['type'] = $membership->type;
+    $result['state'] = $membership->state;
+
+    try {
+      $result['created'] = $this->normalizer->normalize($object->created, $format, $context);
+    }
+    catch (NotNormalizableValueException $exception) {
+      watchdog('gdpr_export', "Could not normalize the field @field_name with type @field_type in entity @entity with bundle @bundle. No supporting normalizer found.", [
+        '@field_name' => 'created',
+        '@field_type' => $object->created->info()['type'],
+        '@entity' => $object->type(),
+        '@bundle' => $object->getBundle(),
+      ], WATCHDOG_WARNING);
+    }
+    catch (EntityMetadataWrapperException $exception) {
+      watchdog_exception('gdpr_export', $exception);
+    }
+
+    $result += $this->getNormalizedFields($object, $format, $context);
+    return $result;
+  }
+
+  /**
+   * Determines if this normalizer matches the object type supplied.
+   *
+   * @inheritdoc
+   */
+  public function supportsNormalization($data, $format = NULL) {
+    return $this->isEntityType($data, 'og_membership');
+  }
+
+}


### PR DESCRIPTION
This PR adds support for exporting the og memberships of an user. I'm not sure what to do with the `field_name` column of the membership table. What is it for? On our instances the fields referenced are always empty.